### PR TITLE
Remove unused radio option and align 1N2 picks

### DIFF
--- a/pronos.php
+++ b/pronos.php
@@ -150,7 +150,7 @@ if ($matches) {
             <input type="number" name="pa[<?=$mid?>]" min="0" style="width:42px" value="<?=($pa!==null?$pa:'')?>" <?= $locked?'disabled':'' ?>>
           </td>
 
-          <td>
+          <td class="pick">
             <?php
               $dH = $locked?'disabled':'';
               $isScore = ($ph !== null && $pa !== null);
@@ -158,7 +158,6 @@ if ($matches) {
             <label><input type="radio" name="pick[<?=$mid?>]" value="H" <?= $pk==='H' && !$isScore?'checked':'' ?> <?=$dH?>> 1</label>
             <label><input type="radio" name="pick[<?=$mid?>]" value="D" <?= $pk==='D' && !$isScore?'checked':'' ?> <?=$dH?>> N</label>
             <label><input type="radio" name="pick[<?=$mid?>]" value="A" <?= $pk==='A' && !$isScore?'checked':'' ?> <?=$dH?>> 2</label>
-            <label><input type="radio" name="pick[<?=$mid?>]" value=""  <?= ($pk===null || $isScore)?'checked':'' ?> <?=$dH?>> -</label>
           </td>
 
           <td>

--- a/style.css
+++ b/style.css
@@ -47,6 +47,19 @@ input {
   background: #0e1116;
   color: #eaecef;
 }
+
+/* Radio buttons for pronos */
+td.pick label {
+  display: inline-flex;
+  align-items: center;
+  margin: 0 8px 0 0;
+}
+
+td.pick input[type=radio] {
+  width: auto;
+  padding: 0;
+  margin-right: 4px;
+}
 button {
   margin-top: 12px;
   padding: 8px 12px;


### PR DESCRIPTION
## Summary
- remove fourth radio option from predictions
- align 1N2 radio buttons inline with custom CSS

## Testing
- `php -l pronos.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8c49199388332b18865df463e5ca6